### PR TITLE
query, proxy: Blocking High-Cardinality Metrics Without Filters from Queries (CLEAN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 
+- [#1](https://github.com/pranavdbnonemu/thanos/pull/1) Thanos Query: add `--block-query-metrics-without-filter` flag to block high-cardinality metric queries without sufficient label filters
+
 ### Changed
 
 ### Removed

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -257,6 +257,8 @@ func registerQuery(app *extkingpin.App) {
 	var storeRateLimits store.SeriesSelectLimits
 	storeRateLimits.RegisterFlags(cmd)
 
+	blockQueryMetricsWithoutFilter := cmd.Flag("block-query-metrics-without-filter", "Comma separated list of metric name patterns to block when they don't have sufficient label filters. This prevents high cardinality queries from overwhelming the backend. Example: 'kube_.*,envoy_.*'").Default("").String()
+
 	cmd.Setup(func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ <-chan struct{}, debugLogging bool) error {
 		selectorLset, err := parseFlagLabels(*selectorLabels)
 		if err != nil {
@@ -397,6 +399,7 @@ func registerQuery(app *extkingpin.App) {
 			*rewriteAggregationLabelTo,
 			*lazyRetrievalMaxBufferedResponses,
 			time.Duration(*grpcStoreClientKeepAlivePingInterval),
+			*blockQueryMetricsWithoutFilter,
 		)
 	})
 }
@@ -485,6 +488,7 @@ func runQuery(
 	rewriteAggregationLabelTo string,
 	lazyRetrievalMaxBufferedResponses int,
 	grpcStoreClientKeepAlivePingInterval time.Duration,
+	blockQueryMetricsWithoutFilter string,
 ) error {
 	comp := component.Query
 	if alertQueryURL == "" {
@@ -578,6 +582,17 @@ func runQuery(
 		store.WithProxyStoreDebugLogging(debugLogging),
 		store.WithQuorumChunkDedup(queryDeduplicationFunc == dedup.AlgorithmQuorum),
 		store.WithLazyRetrievalMaxBufferedResponsesForProxy(lazyRetrievalMaxBufferedResponses),
+	}
+
+	// Parse blocked metric patterns from command line flag
+	if blockQueryMetricsWithoutFilter != "" {
+		blockedPatterns := strings.Split(strings.TrimSpace(blockQueryMetricsWithoutFilter), ",")
+		for i := range blockedPatterns {
+			blockedPatterns[i] = strings.TrimSpace(blockedPatterns[i])
+		}
+		if len(blockedPatterns) > 0 && blockedPatterns[0] != "" {
+			options = append(options, store.WithBlockedMetricPatterns(blockedPatterns))
+		}
 	}
 
 	// Parse and sanitize the provided replica labels flags.

--- a/pkg/store/blocked_metrics_test.go
+++ b/pkg/store/blocked_metrics_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package store
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/thanos/pkg/testutil"
+)
+
+func TestMatchesBlockedPattern(t *testing.T) {
+	testCases := []struct {
+		name        string
+		metricName  string
+		patterns    []string
+		shouldMatch bool
+	}{
+		{
+			name:        "kube metric matches kube pattern",
+			metricName:  "kube_node_info",
+			patterns:    []string{"kube_*"},
+			shouldMatch: true,
+		},
+		{
+			name:        "envoy metric matches envoy pattern",
+			metricName:  "envoy_cluster_stats",
+			patterns:    []string{"envoy_*"},
+			shouldMatch: true,
+		},
+		{
+			name:        "metric matches multiple patterns",
+			metricName:  "kube_pod_info",
+			patterns:    []string{"kube_*", "envoy_*"},
+			shouldMatch: true,
+		},
+		{
+			name:        "metric doesn't match pattern",
+			metricName:  "prometheus_metric",
+			patterns:    []string{"kube_*", "envoy_*"},
+			shouldMatch: false,
+		},
+		{
+			name:        "empty patterns",
+			metricName:  "any_metric",
+			patterns:    []string{},
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := matchesBlockedPattern(tc.metricName, tc.patterns)
+			testutil.Equals(t, tc.shouldMatch, result)
+		})
+	}
+}
+
+func TestHasSufficientFilters(t *testing.T) {
+	testCases := []struct {
+		name      string
+		matchers  []*labels.Matcher
+		shouldHave bool
+	}{
+		{
+			name: "has label equality matcher",
+			matchers: []*labels.Matcher{
+				{Name: "__name__", Type: labels.MatchEqual, Value: "kube_node_info"},
+				{Name: "instance", Type: labels.MatchEqual, Value: "localhost:9100"},
+			},
+			shouldHave: true,
+		},
+		{
+			name: "has regex matcher (not sufficient)",
+			matchers: []*labels.Matcher{
+				{Name: "__name__", Type: labels.MatchEqual, Value: "kube_node_info"},
+				{Name: "instance", Type: labels.MatchRegexp, Value: ".*"},
+			},
+			shouldHave: false,
+		},
+		{
+			name: "only metric name matcher",
+			matchers: []*labels.Matcher{
+				{Name: "__name__", Type: labels.MatchEqual, Value: "kube_node_info"},
+			},
+			shouldHave: false,
+		},
+		{
+			name:       "empty matchers",
+			matchers:   []*labels.Matcher{},
+			shouldHave: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasSufficientFilters(tc.matchers)
+			testutil.Equals(t, tc.shouldHave, result)
+		})
+	}
+}
+
+func TestProxyStore_ShouldBlockQuery(t *testing.T) {
+	testCases := []struct {
+		name           string
+		patterns       []string
+		matchers       []*labels.Matcher
+		shouldBlock    bool
+		expectedReason string
+	}{
+		{
+			name:     "block kube metric without filters",
+			patterns: []string{"kube_*"},
+			matchers: []*labels.Matcher{
+				{Name: "__name__", Type: labels.MatchEqual, Value: "kube_node_info"},
+			},
+			shouldBlock:    true,
+			expectedReason: "metric 'kube_node_info' matches blocked pattern but query lacks sufficient label filters",
+		},
+		{
+			name:     "allow kube metric with filters",
+			patterns: []string{"kube_*"},
+			matchers: []*labels.Matcher{
+				{Name: "__name__", Type: labels.MatchEqual, Value: "kube_node_info"},
+				{Name: "instance", Type: labels.MatchEqual, Value: "localhost:9100"},
+			},
+			shouldBlock:    false,
+			expectedReason: "",
+		},
+		{
+			name:     "allow non-blocked metric",
+			patterns: []string{"kube_*"},
+			matchers: []*labels.Matcher{
+				{Name: "__name__", Type: labels.MatchEqual, Value: "prometheus_metric"},
+			},
+			shouldBlock:    false,
+			expectedReason: "",
+		},
+		{
+			name:     "no patterns configured",
+			patterns: []string{},
+			matchers: []*labels.Matcher{
+				{Name: "__name__", Type: labels.MatchEqual, Value: "kube_node_info"},
+			},
+			shouldBlock:    false,
+			expectedReason: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := &ProxyStore{
+				blockedMetricPatterns: tc.patterns,
+			}
+			shouldBlock, reason := proxy.shouldBlockQuery(tc.matchers)
+			testutil.Equals(t, tc.shouldBlock, shouldBlock)
+			testutil.Equals(t, tc.expectedReason, reason)
+		})
+	}
+}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -102,6 +103,7 @@ type ProxyStore struct {
 	enableDedup                       bool
 	matcherConverter                  *storepb.MatcherConverter
 	lazyRetrievalMaxBufferedResponses int
+	blockedMetricPatterns             []string
 }
 
 type proxyStoreMetrics struct {
@@ -175,6 +177,13 @@ func WithoutDedup() ProxyStoreOption {
 func WithProxyStoreMatcherConverter(mc *storepb.MatcherConverter) ProxyStoreOption {
 	return func(s *ProxyStore) {
 		s.matcherConverter = mc
+	}
+}
+
+// WithBlockedMetricPatterns sets the list of metric patterns that should be blocked when they don't have sufficient label filters.
+func WithBlockedMetricPatterns(patterns []string) ProxyStoreOption {
+	return func(s *ProxyStore) {
+		s.blockedMetricPatterns = patterns
 	}
 }
 
@@ -299,6 +308,12 @@ func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.
 
 	if len(matchers) == 0 {
 		return status.Error(codes.InvalidArgument, errors.New("no matchers specified (excluding selector labels)").Error())
+	}
+
+	// Check if query should be blocked due to high cardinality metric without sufficient filters
+	if shouldBlock, reason := s.shouldBlockQuery(matchers); shouldBlock {
+		level.Info(reqLogger).Log("msg", "Blocked query for high cardinality metric without sufficient filters", "reason", reason)
+		return status.Error(codes.InvalidArgument, fmt.Sprintf("query blocked: %s", reason))
 	}
 
 	// We may arrive here either via the promql engine
@@ -791,7 +806,60 @@ func storeMatchDebugMetadata(s Client, debugLogging bool, storeDebugMatchers [][
 	return true, ""
 }
 
-// LabelSetsMatch returns false if all label-set do not match the matchers (aka: OR is between all label-sets).
+// matchesBlockedPattern checks if a metric name matches any of the blocked patterns.
+func matchesBlockedPattern(metricName string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if matched, _ := filepath.Match(pattern, metricName); matched {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSufficientFilters checks if the matchers have sufficient label filters (non-__name__ equality matchers).
+func hasSufficientFilters(matchers []*labels.Matcher) bool {
+	for _, m := range matchers {
+		// We consider equality matchers on labels other than __name__ as sufficient filters
+		if m.Name != labels.MetricName && m.Type == labels.MatchEqual {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldBlockQuery determines if a query should be blocked based on blocked metric patterns and lack of filters.
+func (s *ProxyStore) shouldBlockQuery(matchers []*labels.Matcher) (bool, string) {
+	if len(s.blockedMetricPatterns) == 0 {
+		return false, ""
+	}
+
+	// Extract metric name from matchers
+	var metricName string
+	for _, m := range matchers {
+		if m.Name == labels.MetricName && m.Type == labels.MatchEqual {
+			metricName = m.Value
+			break
+		}
+	}
+
+	if metricName == "" {
+		return false, ""
+	}
+
+	// Check if metric matches any blocked pattern
+	if !matchesBlockedPattern(metricName, s.blockedMetricPatterns) {
+		return false, ""
+	}
+
+	// Check if query has sufficient filters
+	if hasSufficientFilters(matchers) {
+		return false, ""
+	}
+
+	return true, fmt.Sprintf("metric '%s' matches blocked pattern but query lacks sufficient label filters", metricName)
+}
+
+// LabelSetsMatch returns false if all label-sets do not match the matchers (aka: OR is between all label-sets).
 func LabelSetsMatch(matchers []*labels.Matcher, lset ...labels.Labels) bool {
 	if len(lset) == 0 {
 		return true


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

1: Updated query handling to detect expensive queries based on finding HC metrics w/o filters, metrics need to include filters
2: Blocking logic updated in proxy.go, where processing of the blocking happens
3: added testing in blocked_metrics_test.go which ensures blocking works correctly w/ different patterns
## Verification

<!-- How you tested it? How do you know it works? -->
Created test file which tests pattern matching, filter validation, and integration for blocking queries that have metrics w/ specific patterns feature.